### PR TITLE
Updates to API

### DIFF
--- a/docs/research-app-api.yml
+++ b/docs/research-app-api.yml
@@ -26,6 +26,32 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /providers/{provider_id}/launch/{participant_id}:
+    post:
+      summary: Generate a "launch" URL with a unique "state".
+      tags:
+        - provider
+      parameters:
+        - name: provider_id
+          description: The Provider id
+          in: path
+          required: true
+          type: string
+        - name: participant_id
+          description: The Participant id
+          in: path
+          required: true
+          type: string
+      responses:
+        302:
+          description: Success
+          headers:
+            Location:
+              type: string
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /participants:
     post:
       summary: Create a new participant
@@ -40,7 +66,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  /participants/{participant_id}/authorizations/{provider_id}:
+  /participants/{participant_id}/authorizations:
     post:
       summary: Store an authorization
       tags:
@@ -48,11 +74,6 @@ paths:
       parameters:
         - name: participant_id
           description: The Participant id
-          in: path
-          required: true
-          type: string
-        - name: provider_id
-          description: The Provider id
           in: path
           required: true
           type: string
@@ -70,7 +91,6 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  /participants/{participant_id}/authorizations:
     get:
       summary: Get all the authorizations for a Participant
       tags:

--- a/tests/models/test_participants.py
+++ b/tests/models/test_participants.py
@@ -13,23 +13,10 @@ def test_participant_authorizations():
     # But we can add them
     provider = providers.Provider(fhir_url='http://example.com',
                                   name='Example Provider')
-    participant.authorize(provider, 'AUTHORIZATION_CODE', 'STATE')
+    authorize_url = participant.begin_authorization(provider)
 
+    assert authorize_url
     assert participant.authorizations
-
-    # Until they are active, they don't count
-    assert not participant.authorization(provider)
-
-    try:
-        # pylint: disable=protected-access
-        participant._authorizations[0].status = participants.Authorization.STATUS_ACTIVE
-    finally:
-        pass
-    assert participant.authorization(provider)
-
-    # Once they've been activated, they can't be re-authorized
-    with pytest.raises(participants.AuthorizationException):
-        participant.authorize(provider, 'NEW_AUTHORIZATION_CODE', 'STATE')
 
 
 def test_resource_factories():


### PR DESCRIPTION
Moves creation of Authorization objects to a separate endpoint so that consuming clients don't need to keep track of providers.